### PR TITLE
Refactor http handler to interface pattern for simpler testing in autolinks

### DIFF
--- a/pkg/cmd/repo/autolink/autolink.go
+++ b/pkg/cmd/repo/autolink/autolink.go
@@ -1,6 +1,7 @@
 package autolink
 
 import (
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -9,7 +10,15 @@ func NewCmdAutolink(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "autolink <command>",
 		Short: "Manage autolink references",
-		Long:  "Work with GitHub autolink references.",
+		Long: heredoc.Docf(`
+		Work with GitHub autolink references.
+		
+		GitHub autolinks require admin access to configure and can be found at
+		https://github.com/{owner}/{repo}/settings/key_links.
+		Use %[1]sgh repo autolink list --web%[1]s to open this page for the current repository.
+		
+		For more information about GitHub autolinks, see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
+	`, "`"),
 	}
 	cmdutil.EnableRepoOverride(cmd, f)
 

--- a/pkg/cmd/repo/autolink/http.go
+++ b/pkg/cmd/repo/autolink/http.go
@@ -11,7 +11,17 @@ import (
 	"github.com/cli/cli/v2/internal/ghrepo"
 )
 
-func repoAutolinks(httpClient *http.Client, repo ghrepo.Interface) ([]autolink, error) {
+type AutolinkGetter struct {
+	HttpClient *http.Client
+}
+
+func NewAutolinkGetter(httpClient *http.Client) *AutolinkGetter {
+	return &AutolinkGetter{
+		HttpClient: httpClient,
+	}
+}
+
+func (a *AutolinkGetter) Get(repo ghrepo.Interface) ([]autolink, error) {
 	path := fmt.Sprintf("repos/%s/%s/autolinks", repo.RepoOwner(), repo.RepoName())
 	url := ghinstance.RESTPrefix(repo.RepoHost()) + path
 	req, err := http.NewRequest("GET", url, nil)
@@ -19,7 +29,7 @@ func repoAutolinks(httpClient *http.Client, repo ghrepo.Interface) ([]autolink, 
 		return nil, err
 	}
 
-	resp, err := httpClient.Do(req)
+	resp, err := a.HttpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/repo/autolink/http.go
+++ b/pkg/cmd/repo/autolink/http.go
@@ -36,7 +36,7 @@ func (a *AutolinkGetter) Get(repo ghrepo.Interface) ([]autolink, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == 404 {
-		return nil, fmt.Errorf("error getting autolinks: HTTP 404: Must have admin rights to Repository. (https://api.github.com/repos/%s)", path)
+		return nil, fmt.Errorf("error getting autolinks: HTTP 404: Must have admin rights to Repository. (https://api.github.com/%s)", path)
 	} else if resp.StatusCode > 299 {
 		return nil, api.HandleHTTPError(resp)
 	}

--- a/pkg/cmd/repo/autolink/http.go
+++ b/pkg/cmd/repo/autolink/http.go
@@ -25,7 +25,9 @@ func repoAutolinks(httpClient *http.Client, repo ghrepo.Interface) ([]autolink, 
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode > 299 {
+	if resp.StatusCode == 404 {
+		return nil, fmt.Errorf("error getting autolinks: HTTP 404: Must have admin rights to Repository. (https://api.github.com/repos/%s)", path)
+	} else if resp.StatusCode > 299 {
 		return nil, api.HandleHTTPError(resp)
 	}
 

--- a/pkg/cmd/repo/autolink/http_test.go
+++ b/pkg/cmd/repo/autolink/http_test.go
@@ -1,0 +1,79 @@
+package autolink
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAutolinkGetter(t *testing.T) {
+	httpClient := &http.Client{}
+	autolinkGetter := NewAutolinkGetter(httpClient)
+	assert.NotNil(t, autolinkGetter)
+}
+
+func TestAutoLinkGetter_Get(t *testing.T) {
+	tests := []struct {
+		name   string
+		repo   ghrepo.Interface
+		resp   []autolink
+		status int
+	}{
+		{
+			name:   "no autolinks",
+			repo:   ghrepo.New("OWNER", "REPO"),
+			resp:   []autolink{},
+			status: 200,
+		},
+		{
+			name: "two autolinks",
+			repo: ghrepo.New("OWNER", "REPO"),
+			resp: []autolink{
+				{
+					ID:             1,
+					IsAlphanumeric: true,
+					KeyPrefix:      "key",
+					URLTemplate:    "https://example.com",
+				},
+				{
+					ID:             2,
+					IsAlphanumeric: false,
+					KeyPrefix:      "key2",
+					URLTemplate:    "https://example2.com",
+				},
+			},
+			status: 200,
+		},
+		{
+			name:   "http error",
+			repo:   ghrepo.New("OWNER", "REPO"),
+			status: 404,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			reg.Register(
+				httpmock.REST("GET", fmt.Sprintf("repos/%s/%s/autolinks", tt.repo.RepoOwner(), tt.repo.RepoName())),
+				httpmock.StatusJSONResponse(tt.status, tt.resp),
+			)
+			defer reg.Verify(t)
+
+			autolinkGetter := NewAutolinkGetter(&http.Client{Transport: reg})
+			autolinks, err := autolinkGetter.Get(tt.repo)
+			if tt.status == 404 {
+				require.Error(t, err)
+				assert.Equal(t, "error getting autolinks: HTTP 404: Must have admin rights to Repository. (https://api.github.com/repos/OWNER/REPO/autolinks)", err.Error())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.resp, autolinks)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Changes

This builds on https://github.com/cli/cli/pull/10124, where @hoffm has begun implementing the `gh repo autolink` feature set. In particular, this is in response to [this PR comment](https://github.com/cli/cli/pull/10124/files#r1896122379): it refactors the design of the http handler to an interface pattern. This allows for much simpler testing by leveraging dependency injection for `listRun()`. 

This addresses a pain-point in the current testing pattern in the repo, where the `httpmock` pattern is used for testing commands, creating difficult to understand and maintain testing suites.

Hopefully the advantages of this approach are apparent in the simplicity of the tests and can be leveraged for the rest of the `gh repo autolink` commands.

## Testing

1. Build the binary with `make`
2. Run `bin/gh repo autolink list -R <OWNER/REPO>`

The unit tests do a great job of giving me confidence that this is performing as expected, now, and that confidence should translate to any changes to the peripheral functionality in the command set.